### PR TITLE
Improve buffer handling in SDL_tinspirevideo

### DIFF
--- a/src/video/tinspire/SDL_tinspirevideo.h
+++ b/src/video/tinspire/SDL_tinspirevideo.h
@@ -45,7 +45,6 @@ struct SDL_PrivateVideoData {
 	int offset;
 	int win_x;
 	void *buffer;
-	void *buffer2;
 	int cx;
 };
 


### PR DESCRIPTION
- Don't assign a global buffer to the video surface to support multiple calls
  to SetVideoMode without double frees on failure
- Allocate the buffer for lcd_blit on device initialization